### PR TITLE
update go version to v1.23

### DIFF
--- a/.changes/unreleased/Fixed-20241201-145101.yaml
+++ b/.changes/unreleased/Fixed-20241201-145101.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Update go version to 1.23
+time: 2024-12-01T14:51:01.142811308-08:00
+custom:
+    Issue: "11"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "18:00"
+      timezone: "America/Los_Angeles"
+    labels:
+      - "skip changelog"
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "18:00"
+      timezone: "America/Los_Angeles"
+    labels:
+      - "skip changelog"
+      - "dependencies"
+    groups:
+      action-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: 1.23
 
     - name: Run benchmark and push
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: 1.23
 
     - name: Get the latest version
       id: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: 1.23
 
     - name: Check out code
       uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       with:
         # Required: the version of golangci-lint is required and must be specified
         # without patch version: we always use the latest patch version.
-        version: v1.57
+        version: v1.62
 
     - name: Test
       run: go test -coverprofile=c.out ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,15 @@ linters-settings:
   goconst:
     min-len: 5
     min-occurrences: 5
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/org/project) # Custom section: groups all imports with the specified Prefix.
+      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+      - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
+      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
   goimports:
     local-prefixes: github.com/miniscruff/scopie-go
   golint:
@@ -23,9 +32,9 @@ linters:
     - dupl
     - errcheck
     - exhaustive
+    - gci
     - goconst
     - gofmt
-    - goimports
     - goprintffuncname
     - gosec
     - gosimple

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,4 @@ bench: # Run benchmark test suite
 
 .PHONY: format
 format: # Run linter and formatters
-	goimports -w -local github.com/miniscruff/scopie-go .
-	golangci-lint run ./...
+	golangci-lint run --fix ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/miniscruff/scopie-go
 
-go 1.21
+go 1.23


### PR DESCRIPTION
add dependabot config
small linter rule change
update ci versions for go as well

closes #11
